### PR TITLE
Sets packer max_jobs to 10

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -14,7 +14,7 @@ vim.api.nvim_create_autocmd("BufWritePost", {
   command = "source <afile> | PackerCompile",
 })
 
-require('packer').init({display = {auto_clean = false}})
+require('packer').init({display = {auto_clean = false}, max_jobs = 10})
 
 return require('packer').startup(function(use)
 


### PR DESCRIPTION
Otherwise packers starts as many jobs as plugins causing some of them to fail